### PR TITLE
Fix getting external ip

### DIFF
--- a/lib/docker_container_updater/updater.rb
+++ b/lib/docker_container_updater/updater.rb
@@ -85,7 +85,7 @@ module DockerContainerUpdater
 
     # @return [String] external ip
     def my_external_ip
-      URI.parse('http://ipinfo.io/ip').open.read.chop
+      URI.parse('http://ipinfo.io/ip').open.read.chomp
     end
 
     # @return [String] text example url


### PR DESCRIPTION
Seems `http://ipinfo.io/ip` change return value and no longer adding newline to this page at end

Old code resulting of truncating last digit:
![image](https://user-images.githubusercontent.com/668524/108050600-e23dca80-705a-11eb-8dc5-5b53fcd65075.png)
