### PR TITLE
Fix `iptable` failure on docker install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Fixes
 
 * Fix `markdownlint` failure because of old `nodejs` in CI
+* Fix `iptable` failure on docker install
 
 ### Changes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ FROM onlyofficetestingrobot/nct-at-testing-node
 LABEL maintainer="shockwavenn@gmail.com"
 
 RUN apt-get update && \
-    apt-get -y install \
+    apt-get -y --allow-downgrades install  \
         apt-transport-https \
         ca-certificates \
         curl \
         dnsutils \
+        iptables/stable \
         software-properties-common
 RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add -
 RUN add-apt-repository \


### PR DESCRIPTION
It was causing
```
The following packages have unmet dependencies:
 iptables : Depends: libxtables12 (= 1.8.7-1) but 1.8.8-1 is to be installed
            Recommends: nftables but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

Workaround by downgrading iptable versions